### PR TITLE
Improving performance of Fuller's `to_sphere`

### DIFF
--- a/src/basetri.rs
+++ b/src/basetri.rs
@@ -26,13 +26,12 @@ impl BaseTriSphere {
     /// The length of any edge on this base shape, or equivalently, the angle between any
     /// two adjacent vertices.
     pub const fn edge_length(self) -> f64 {
-        [1.1071487177940904, std::f64::consts::FRAC_PI_2][self as usize]
+        self.consts().angle
     }
 
-    /// The cosine of [`edge_length`](BaseTriSphere::edge_length`), or equivalently, the dot
-    /// product between any two adjacent vertices.
-    pub const fn edge_cos_length(self) -> f64 {
-        [C_1, 0.0][self as usize]
+    /// The constants associated with this base shape.
+    pub(crate) const fn consts(self) -> &'static Consts {
+        &CONSTS[self as usize]
     }
 
     /// The internal representation of the first face of this base shape.
@@ -365,6 +364,40 @@ impl crate::HalfEdge for HalfEdge {
         (*self).next()
     }
 }
+
+/// Constants associated with a particular [`BaseTriSphere`].
+pub(crate) struct Consts {
+    /// The angle between two adjacent vertices on the sphere.
+    pub angle: f64,
+
+    /// `sin(angle / 2)`
+    pub sin_half_angle: f64,
+
+    /// `cos(angle / 2)`
+    pub cos_half_angle: f64,
+
+    /// `tan(angle / 2)`
+    pub tan_half_angle: f64,
+}
+
+static CONSTS: [Consts; 2] = const {
+    [
+        // Icosahedron
+        Consts {
+            angle: 1.1071487177940904,
+            sin_half_angle: C_5,
+            cos_half_angle: C_3,
+            tan_half_angle: C_5 / C_3,
+        },
+        // Octahedron
+        Consts {
+            angle: std::f64::consts::FRAC_PI_2,
+            sin_half_angle: std::f64::consts::FRAC_1_SQRT_2,
+            cos_half_angle: std::f64::consts::FRAC_1_SQRT_2,
+            tan_half_angle: 1.0,
+        },
+    ]
+};
 
 /// Table used to implement [`crate::Vertex::outgoing`].
 static OUTGOING: [[HalfEdge; 5]; NUM_VERTS] = const {

--- a/src/math.rs
+++ b/src/math.rs
@@ -55,13 +55,7 @@ pub(crate) mod vec {
     /// Divides a vector by a scalar.
     #[inline]
     pub const fn div<const N: usize>(a: [f64; N], b: f64) -> [f64; N] {
-        let mut res = [0.0; N];
-        let mut i = 0;
-        while i < N {
-            res[i] = a[i] / b;
-            i += 1;
-        }
-        res
+        mul(a, 1.0 / b)
     }
 
     /// Computes the dot product of two vectors.

--- a/src/math.rs
+++ b/src/math.rs
@@ -55,6 +55,9 @@ pub(crate) mod vec {
     /// Divides a vector by a scalar.
     #[inline]
     pub const fn div<const N: usize>(a: [f64; N], b: f64) -> [f64; N] {
+        // Since division is more expensive than multiplication, we actually multiply `a` by the
+        // reciprocal of `b`. This introduces a very small amount of error, so we may need to
+        // re-evaluate if/when we have tighter requirements for numerical error.
         mul(a, 1.0 / b)
     }
 

--- a/src/proj/fuller.rs
+++ b/src/proj/fuller.rs
@@ -13,21 +13,34 @@ impl Fuller {
     /// must be equilateral, with the angle between any two endpoints equal to `angle`.
     pub fn triangle(self, angle: f64, points: [[f64; 3]; 3]) -> Triangle {
         // TODO: Validate triangle when debug assertions are on
-        Triangle { angle, points }
+        let sin_half_angle = (angle / 2.0).sin();
+        let cos_half_angle = (angle / 2.0).cos();
+        let tan_half_angle = sin_half_angle / cos_half_angle;
+        Triangle {
+            angle,
+            sin_half_angle,
+            cos_half_angle,
+            tan_half_angle,
+            points,
+        }
     }
 }
 
 impl BaseTriProjector for Fuller {
     type Triangle = Triangle;
     fn inside(&self, edge: basetri::HalfEdge) -> Triangle {
-        self.triangle(
-            edge.sphere().edge_length(),
-            [
+        let consts = edge.sphere().consts();
+        Triangle {
+            angle: consts.angle,
+            sin_half_angle: consts.sin_half_angle,
+            cos_half_angle: consts.cos_half_angle,
+            tan_half_angle: consts.tan_half_angle,
+            points: [
                 edge.start().pos(),
                 edge.next().start().pos(),
                 edge.prev().start().pos(),
             ],
-        )
+        }
     }
 }
 
@@ -36,6 +49,15 @@ impl BaseTriProjector for Fuller {
 pub struct Triangle {
     /// The angle, in radians, between any two endpoints of the triangle.
     angle: f64,
+
+    /// `sin(angle / 2)`
+    sin_half_angle: f64,
+
+    /// `cos(angle / 2)`
+    cos_half_angle: f64,
+
+    /// `tan(angle / 2)`
+    tan_half_angle: f64,
 
     /// The positions of the endpoints of the triangle on the sphere.
     points: [[f64; 3]; 3],
@@ -69,7 +91,7 @@ impl Projection for Triangle {
 
         // First, solve the equation:
         // `tan(x + proj_u) + tan(x) + tan(x + proj_v) + t_alpha = 0`
-        let t_alpha = (self.angle / 2.0).tan();
+        let t_alpha = self.tan_half_angle;
         let proj_u = (2.0 * u + v - 1.0) * self.angle;
         let proj_v = (2.0 * v + u - 1.0) * self.angle;
         let t_half_proj_u = (proj_u / 2.0).tan();
@@ -107,25 +129,29 @@ impl Projection for Triangle {
         .min_by(|(_, a), (_, b)| a.abs().partial_cmp(&b.abs()).unwrap())
         .unwrap();
 
-        let x = t_x.atan();
-
         // Use the solution to compute angle offsets of two planes from the second and
-        // third edges of the triangle
-        let a_0 = self.angle / 2.0 - x;
-        let a_1 = a_0 - (2.0 * u + v - 1.0) * self.angle;
-
-        // Construct planes by offsetting the second and third edges of the triangle
+        // third edges of the triangle. Construct planes by offsetting the second and third edges
+        // of the triangle
+        let s_alpha = self.sin_half_angle;
+        let c_alpha = self.cos_half_angle;
+        let s_k_proj_u = 2.0 * t_half_proj_u;
+        let c_k_proj_u = 1.0 - t_half_proj_u * t_half_proj_u;
         let n_0 = vec::cross(
             mat::apply(
                 [self.points[0], self.points[1]],
-                [(self.angle - a_0).sin(), a_0.sin()],
+                [s_alpha + c_alpha * t_x, s_alpha - c_alpha * t_x],
             ),
             vec::sub(self.points[2], self.points[1]),
         );
         let n_1 = vec::cross(
             mat::apply(
                 [self.points[1], self.points[2]],
-                [(self.angle - a_1).sin(), a_1.sin()],
+                [
+                    s_alpha * (c_k_proj_u - t_x * s_k_proj_u)
+                        + c_alpha * (t_x * c_k_proj_u + s_k_proj_u),
+                    s_alpha * (c_k_proj_u - t_x * s_k_proj_u)
+                        - c_alpha * (t_x * c_k_proj_u + s_k_proj_u),
+                ],
             ),
             vec::sub(self.points[0], self.points[2]),
         );

--- a/src/proj/fuller.rs
+++ b/src/proj/fuller.rs
@@ -132,27 +132,18 @@ impl Projection for Triangle {
         // Use the solution to compute angle offsets of two planes from the second and
         // third edges of the triangle. Construct planes by offsetting the second and third edges
         // of the triangle
-        let s_alpha = self.sin_half_angle;
-        let c_alpha = self.cos_half_angle;
-        let s_k_proj_u = 2.0 * t_half_proj_u;
-        let c_k_proj_u = 1.0 - t_half_proj_u * t_half_proj_u;
+        let s_0 = self.sin_half_angle;
+        let c_0 = self.cos_half_angle * t_x;
         let n_0 = vec::cross(
-            mat::apply(
-                [self.points[0], self.points[1]],
-                [s_alpha + c_alpha * t_x, s_alpha - c_alpha * t_x],
-            ),
+            mat::apply([self.points[0], self.points[1]], [s_0 + c_0, s_0 - c_0]),
             vec::sub(self.points[2], self.points[1]),
         );
+        let s_k_proj_u = 2.0 * t_half_proj_u;
+        let c_k_proj_u = 1.0 - t_half_proj_u * t_half_proj_u;
+        let s_1 = self.sin_half_angle * (c_k_proj_u - t_x * s_k_proj_u);
+        let c_1 = self.cos_half_angle * (t_x * c_k_proj_u + s_k_proj_u);
         let n_1 = vec::cross(
-            mat::apply(
-                [self.points[1], self.points[2]],
-                [
-                    s_alpha * (c_k_proj_u - t_x * s_k_proj_u)
-                        + c_alpha * (t_x * c_k_proj_u + s_k_proj_u),
-                    s_alpha * (c_k_proj_u - t_x * s_k_proj_u)
-                        - c_alpha * (t_x * c_k_proj_u + s_k_proj_u),
-                ],
-            ),
+            mat::apply([self.points[1], self.points[2]], [s_1 + c_1, s_1 - c_1]),
             vec::sub(self.points[0], self.points[2]),
         );
 


### PR DESCRIPTION
Basically just applying [trig identities](https://en.wikipedia.org/wiki/List_of_trigonometric_identities) to factor out expensive trig calls and replace them with constants. According to my testing, it improves performance of `to_sphere` by about 20% 